### PR TITLE
Fixed hdf-cffi so that it can find libhdf5.so on Debian

### DIFF
--- a/hdf-cffi/hdf-cffi.lisp
+++ b/hdf-cffi/hdf-cffi.lisp
@@ -22,6 +22,8 @@
 (in-package :cl-ana.hdf-cffi)
 
 (define-foreign-library hdf5
+  (:unix (:or "/usr/lib/i386-linux-gnu/hdf5/serial/libhdf5.so"
+              "/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.so"))
   (t (:default "libhdf5")))
 
 (use-foreign-library hdf5)


### PR DESCRIPTION
On Debian Jessie (and later), cl-ana is unable to find the libhdf5.so file since it is not located in the base /usr/lib folder.

I've fixed this problem by adding the path to libhdf5.so on Debian for both the i386 and x86_64 architectures. 