### PR TITLE
Added a support for Gnuplot's qt terminal device

### DIFF
--- a/plotting/package.lisp
+++ b/plotting/package.lisp
@@ -96,6 +96,7 @@
            :ps-term
            :eps-term
            :pdf-term
-           :epslatex-term))
+           :epslatex-term
+           :qt-term))
 
 (cl-ana.gmath:use-gmath :cl-ana.plotting)

--- a/plotting/plotting.lisp
+++ b/plotting/plotting.lisp
@@ -1536,7 +1536,7 @@ gnuplot to distinguish eps from ps)"
                         ;; argument
                         (header nil header-supplied-p)
                         blacktext-p)
-  "Generates the type string for a png terminal with options"
+  "Generates the type string for a epslatex terminal with options"
   (apply #'join-strings
          (intersperse
           " "
@@ -1595,3 +1595,26 @@ gnuplot to distinguish eps from ps)"
                   (if blacktext-p
                       "blacktext"
                       "colortext")))))))
+
+(defun qt-term (&key
+                  window-number
+                  (size (cons 640 480))
+                  enhanced-p
+                  font
+                  title
+                  persist-p)
+  "Generates the type string for a qt terminal with options"
+  (format nil "~{~a ~}"
+          (remove nil
+                  (list "qt"
+                        (when window-number
+                          (format nil "~a" window-number))
+                        (format nil "size ~a, ~a" (car size) (cdr size))
+                        (when enhanced-p
+                          "enhanced")
+                        (when font
+                          (format nil "font \"~a\"" font))
+                        (when title
+                          (format nil "title \"~a\"" title))
+                        (when persist-p
+                          "persist")))))


### PR DESCRIPTION
Hello,

I've added a support for the qt terminal device to cl-ana. The qt terminal device is the default interactive output of Gnuplot on Debian, where the wxt terminal is not available.

The new qt-term function also accepts keyword arguments, just like other term functions in cl-ana. I've tried to mimic cl-ana term functions as best as I could.  

I've done some preliminary testing, and have found no problem with the new qt-term function so far. 