### PR TITLE
Minor bug patch in unit multiplication

### DIFF
--- a/quantity/unit.lisp
+++ b/quantity/unit.lisp
@@ -108,10 +108,16 @@ being expressed with explicit exponent."
       1
       x))
 
+(defun unwrap-single (l)
+  (if (single l)
+      (car l)
+      l))
+
 (defun unit-simplify (u)
   "Expects u to be in standard form"
-  (one-if-null
-   (un-singleton-zero u)))
+  (unwrap-single
+   (one-if-null
+    (un-singleton-zero u))))
 
 (defun unit-mult (unit1 unit2)
   (labels ((ucoef (u)


### PR DESCRIPTION
Unit multiplication has a bug where it will sometimes return a
list containing one unit without an exponent. This confuses other
parts of the quantity library, so this patch adds a check which
unwraps the unneeded list.

Test:
`(unit-mult '((:meter 2)) '((:meter -1)))` produces '(:meter) instead of just :meter, creating quantities which break when used in later calculations.

This was an odd one to debug, as the quantity printer is already well prepared for printing lists of quantities, so I could only see the problem by inspecting the actual quantity objects.