### PR TITLE
Fixing portability issues for non-SBCL lisps

### DIFF
--- a/makeres/logres.lisp
+++ b/makeres/logres.lisp
@@ -165,9 +165,7 @@
           do
           ;; delete save-path recursively
             (when (probe-file (target-path id))
-              #+sbcl
-              (sb-ext:delete-directory (target-path id)
-                                       :recursive t))
+              (uiop:delete-directory-tree (target-path id)))
             (ensure-directories-exist (target-path id))
             (let ((destruct-on-save?
                    (destruct-on-save?
@@ -206,9 +204,7 @@
           finally (return t))
        ;; delete save-path recursively
        (when (probe-file (target-path id))
-         #+sbcl
-         (sb-ext:delete-directory (target-path id)
-                                  :recursive t))
+         (uiop:delete-directory-tree (target-path id)))
        (ensure-directories-exist (target-path id))
        (let ((destruct-on-save?
               (destruct-on-save?
@@ -696,8 +692,7 @@ to this project."
           (:supersede
            ;; delete save-path recursively
            #+sbcl
-           (sb-ext:delete-directory save-path
-                                    :recursive t))))
+           (uiop:delete-directory-tree save-path))))
       ;; need save-path to exist before writing:
       (ensure-directories-exist save-path)
       ;; allocate indices when necessary:
@@ -791,7 +786,7 @@ to this project."
             (work-from-path (merge-pathnames "work/"
                                              project-path)))
         (when (probe-file work-to-path)
-          #+sbcl (sb-ext:delete-directory work-to-path :recursive t))
+          (uiop:delete-directory-tree work-to-path))
         (format t "Saving work/ files~%")
         (run-prog "/usr/bin/cp"
                   (list "-r"
@@ -994,7 +989,7 @@ will be returned."
     (when (probe-file destpath)
       (format t "Overwriting old snapshot at ~a~%"
               destpath)
-      (sb-ext:delete-directory destpath :recursive t))
+      (uiop:delete-directory-tree destpath))
     (format t "Copying ~a to ~a~%"
             (current-path) destpath)
     (run "cp" (list "-r"
@@ -1031,11 +1026,11 @@ does not backup if backup is NIL."
                                            :directory (list :relative backup))
                                           (project-path)))
         (when (probe-file backuppath)
-          (sb-ext:delete-directory backuppath :recursive t))
+          (uiop:delete-directory-tree backuppath))
         (run-prog "/usr/bin/cp" (list "-r"
                                       (current-path)
                                       backuppath))))
-    (sb-ext:delete-directory (current-path) :recursive t)
+    (uiop:delete-directory-tree (current-path))
     (run-prog "/usr/bin/cp" (list "-r"
                                   sourcepath
                                   (current-path)))

--- a/makeres/logres.lisp
+++ b/makeres/logres.lisp
@@ -165,7 +165,7 @@
           do
           ;; delete save-path recursively
             (when (probe-file (target-path id))
-              (uiop:delete-directory-tree (target-path id)))
+              (uiop:delete-directory-tree (make-pathname :directory `(:relative ,(target-path id)) :validate t)))
             (ensure-directories-exist (target-path id))
             (let ((destruct-on-save?
                    (destruct-on-save?
@@ -204,7 +204,7 @@
           finally (return t))
        ;; delete save-path recursively
        (when (probe-file (target-path id))
-         (uiop:delete-directory-tree (target-path id)))
+         (uiop:delete-directory-tree (make-pathname :directory `(:relative ,(target-path id))) :validate t))
        (ensure-directories-exist (target-path id))
        (let ((destruct-on-save?
               (destruct-on-save?
@@ -691,8 +691,7 @@ to this project."
           (nil (return-from save-project nil))
           (:supersede
            ;; delete save-path recursively
-           #+sbcl
-           (uiop:delete-directory-tree save-path))))
+           (uiop:delete-directory-tree save-path :validate t))))
       ;; need save-path to exist before writing:
       (ensure-directories-exist save-path)
       ;; allocate indices when necessary:
@@ -786,7 +785,7 @@ to this project."
             (work-from-path (merge-pathnames "work/"
                                              project-path)))
         (when (probe-file work-to-path)
-          (uiop:delete-directory-tree work-to-path))
+          (uiop:delete-directory-tree work-to-path :validate t))
         (format t "Saving work/ files~%")
         (run-prog "/usr/bin/cp"
                   (list "-r"
@@ -989,7 +988,7 @@ will be returned."
     (when (probe-file destpath)
       (format t "Overwriting old snapshot at ~a~%"
               destpath)
-      (uiop:delete-directory-tree destpath))
+      (uiop:delete-directory-tree destpath :validate t))
     (format t "Copying ~a to ~a~%"
             (current-path) destpath)
     (run "cp" (list "-r"
@@ -1026,11 +1025,11 @@ does not backup if backup is NIL."
                                            :directory (list :relative backup))
                                           (project-path)))
         (when (probe-file backuppath)
-          (uiop:delete-directory-tree backuppath))
+          (uiop:delete-directory-tree backuppath :validate t))
         (run-prog "/usr/bin/cp" (list "-r"
                                       (current-path)
                                       backuppath))))
-    (uiop:delete-directory-tree (current-path))
+    (uiop:delete-directory-tree (current-path) :validate t)
     (run-prog "/usr/bin/cp" (list "-r"
                                   sourcepath
                                   (current-path)))

--- a/makeres/makeres.lisp
+++ b/makeres/makeres.lisp
@@ -1597,7 +1597,7 @@ which should be shown."
                 (progn
                   (format t "Deleting ~a~%"
                           logged-id)
-                  (uiop:delete-directory-tree logged-path))
+                  (uiop:delete-directory-tree logged-path :validate t))
                 (format t "~a not tracked~%"
                         logged-id))))))
 
@@ -1616,7 +1616,7 @@ logs."
            for id in null-stats
            do (progn
                 (format t "Deleting ~s~%" id)
-                (uiop:delete-directory-tree (target-path id))))
+                (uiop:delete-directory-tree (make-pathname :directory `(:relative ,(target-path id))) :validate t)))
         (loop
            for id in null-stats
            do (format t "~s~%" id)))))

--- a/makeres/makeres.lisp
+++ b/makeres/makeres.lisp
@@ -1597,8 +1597,7 @@ which should be shown."
                 (progn
                   (format t "Deleting ~a~%"
                           logged-id)
-                  (sb-ext:delete-directory logged-path
-                                           :recursive t))
+                  (uiop:delete-directory-tree logged-path))
                 (format t "~a not tracked~%"
                         logged-id))))))
 
@@ -1617,8 +1616,7 @@ logs."
            for id in null-stats
            do (progn
                 (format t "Deleting ~s~%" id)
-                (sb-ext:delete-directory (target-path id)
-                                         :recursive t)))
+                (uiop:delete-directory-tree (target-path id))))
         (loop
            for id in null-stats
            do (format t "~s~%" id)))))

--- a/plotting/plotting.lisp
+++ b/plotting/plotting.lisp
@@ -67,7 +67,7 @@
 ;;;; but a suggestion to a similar concern was to use multiple
 ;;;; sessions so I'll see what happens.
 
-(defvar *gnuplot-file-io* "/tmp/cl-ana.plotting/"
+(defvar *gnuplot-file-io* (list "tmp" "cl-ana.plotting")
   "Set to a directory path to use files for data to be transferred to
 gnuplot via files instead of pipes.  Value of NIL indicates pipe IO to
 be used for data transfer, but this is potentially unsafe for large
@@ -126,11 +126,7 @@ transfers and can lead to hard to diagnose bugs.")
   )
 
 (defun plotdir ()
-  (mkdirpath (->absolute-pathname
-              (string-append
-               (namestring *gnuplot-file-io*)
-               "/"
-               (mkstr (getpid))))))
+  (make-pathname :directory `(:relative ,@*gnuplot-file-io* ,(mkstr (getpid)))))
 
 (defun reset-data-path ()
   (when *gnuplot-file-io*

--- a/plotting/plotting.lisp
+++ b/plotting/plotting.lisp
@@ -94,7 +94,7 @@ transfers and can lead to hard to diagnose bugs.")
                                         i)
                                 (make-pathname :directory
                                                (namestring plotdir)))))
-	(uiop:delete-directory-tree plotdir)))))
+	(uiop:delete-directory-tree plotdir :validate t)))))
 
 (defparameter *plotting-exit-hook-p* nil)
 (defun ensure-exit-hook ()
@@ -150,7 +150,7 @@ transfers and can lead to hard to diagnose bugs.")
               (when (probe-file pn)
                 (delete-file pn))))
       (when (probe-file dir)
-	(uiop:delete-directory-tree dir))
+	(uiop:delete-directory-tree dir :validate t))
       (setf *gnuplot-file-io-index* 0))))
 
 (defun next-data-path ()

--- a/plotting/plotting.lisp
+++ b/plotting/plotting.lisp
@@ -94,11 +94,8 @@ transfers and can lead to hard to diagnose bugs.")
                                         i)
                                 (make-pathname :directory
                                                (namestring plotdir)))))
-        #+sbcl
-        (sb-ext:delete-directory plotdir)
-        #+clisp
-        (ext:delete-dir (make-pathname :directory
-                                       (namestring plotdir)))))))
+	(uiop:delete-directory-tree plotdir)))))
+
 (defparameter *plotting-exit-hook-p* nil)
 (defun ensure-exit-hook ()
   (when (not *plotting-exit-hook-p*)
@@ -106,6 +103,8 @@ transfers and can lead to hard to diagnose bugs.")
     (push #'plotting-exit-hook sb-ext:*exit-hooks*)
     #+clisp
     (push #'plotting-exit-hook custom:*fini-hooks*)
+    #+clozure
+    (push #'plotting-exit-hook ccl:*lisp-cleanup-functions*)
     (setf *plotting-exit-hook-p* t)))
 (ensure-exit-hook)
 
@@ -120,6 +119,8 @@ transfers and can lead to hard to diagnose bugs.")
   (sb-posix:getpid)
   #+clisp
   (system::process-id)
+  #+clozure
+  (ccl::getpid)
   ;; Can't seem to find information on how to do this for other
   ;; implementations
   )
@@ -149,8 +150,7 @@ transfers and can lead to hard to diagnose bugs.")
               (when (probe-file pn)
                 (delete-file pn))))
       (when (probe-file dir)
-        #+sbcl
-        (sb-ext:delete-directory dir))
+	(uiop:delete-directory-tree dir))
       (setf *gnuplot-file-io-index* 0))))
 
 (defun next-data-path ()


### PR DESCRIPTION
Changed `sb-ext:delete-directory` to `uiop:delete-directory-tree`
Added CCL-specific code for non-portable content not supported by uiop (getpid, exit-hooks)
This should address #20